### PR TITLE
Made Dockerfile install ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,8 @@ FROM python:3
 ADD ./ /
 
 RUN pip install -r requirements.txt
+RUN apt-get -y update
+RUN apt-get -y upgrade
+RUN apt-get -y install ffmpeg
 
 CMD [ "python", "./main.py" ]


### PR DESCRIPTION
This makes Dockerfile install ffmpeg, which is used by youtube-dl. Before this fix, when you used the Dockerized version to download a youtube video, it would always give a `.webm` extension and wouldn't show the thumbnail. I've tested this and this PR fixes that.